### PR TITLE
feat(module): add variable to allow to pass filter to find the right ami

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,45 @@ This work is licensed under the MIT license. See LICENSE file for details.
 ## Author Information
 
 This project was started in 2019 by [David Alger](https://davidalger.com/).
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.14 |
+| aws | ~> 3.4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 3.4.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| authorized\_keys | list of ssh pub key allowed to ssh | `list(any)` | n/a | yes |
+| instance\_filter | provide a map of filter to search Instance ID (see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | <pre>list(object({<br>    name   = string<br>    values = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "name": "name",<br>    "values": [<br>      "CentOS 7.9.2009 x86_64"<br>    ]<br>  }<br>]</pre> | no |
+| instance\_owner | List of AMI owners to limit search. At least 1 value must be specified. Valid values: an AWS account ID, self (the current account), or an AWS owner alias (e.g. amazon, aws-marketplace, microsoft). Default to centos public account | `list(string)` | <pre>[<br>  "125523088429"<br>]</pre> | no |
+| instance\_type | instance type to deploy | `string` | `"c5.2xlarge"` | no |
+| instance\_user | service account to run jmeter | `string` | `"jmeter"` | no |
+| jmeter\_scenario | a path to a jmeter jmx file tu upload to the ec2 it will be uploaded to /tmp/jmeter.jmx | `string` | `"../jmeter.jmx"` | no |
+| jmeter\_version | jmeter version | `string` | `"5.1.1"` | no |
+| name | n/a | `string` | n/a | yes |
+| security\_groups | Additional security groups to attach to the jmeter instance. | `list(string)` | `[]` | no |
+| subnet\_id | n/a | `string` | n/a | yes |
+| tags | n/a | `map(string)` | n/a | yes |
+| trusted\_ip\_ranges | List of IP ranges to whitelist for ICMP and SSH ingress. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| vpc\_id | n/a | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| instance\_address | n/a |
+| instance\_arn | n/a |
+| instance\_id | n/a |
+| instance\_name | n/a |
+| instance\_user | n/a |
+

--- a/main.tf
+++ b/main.tf
@@ -65,13 +65,22 @@ locals {
 }
 
 data "aws_ami" "centos" {
+  owners      = ["679593333241"]
   most_recent = true
-  owners      = ["aws-marketplace"]
 
-  ## CentOS Linux 7 x86_64 HVM EBS ENA 1804_2
   filter {
-    name   = "product-code"
-    values = ["aw0evgkw8e5c1q413zgy5pjce"]
+    name   = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS *"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -70,17 +70,7 @@ data "aws_ami" "centos" {
 
   filter {
     name   = "name"
-    values = ["CentOS 7 (x86_64) - with Updates HVM *"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
+    values = ["CentOS 7.9.2009 x86_64"]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -65,12 +65,12 @@ locals {
 }
 
 data "aws_ami" "centos" {
-  owners      = ["679593333241"]
+  owners      = ["125523088429"]
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["CentOS Linux 7 x86_64 HVM EBS *"]
+    values = ["CentOS 7 (x86_64) - with Updates HVM *"]
   }
 
   filter {

--- a/main.tf
+++ b/main.tf
@@ -53,9 +53,14 @@ locals {
       content     = filebase64("${path.module}/files/profile.d/boilerplate.sh")
     },
     {
+      path        = "/tmp/jmeter.jmx"
+      permissions = "0644"
+      content     = filebase64(var.jmeter_scenario)
+    },
+    {
       path        = "/usr/local/bin/setup-jmeter.sh"
       permissions = "0755"
-      content     = base64encode(replace(
+      content = base64encode(replace(
         file("${path.module}/files/setup-jmeter.sh"),
         "/JMETER_VERSION=.*/",
         "JMETER_VERSION=${var.jmeter_version}",
@@ -65,12 +70,14 @@ locals {
 }
 
 data "aws_ami" "centos" {
-  owners      = ["125523088429"]
+  owners      = var.instance_owner
   most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["CentOS 7.9.2009 x86_64"]
+  dynamic "filter" {
+    for_each = var.instance_filter
+    content {
+      name   = lookup(filter.value, "name", "name")
+      values = lookup(filter.value, "values", [])
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,24 +21,49 @@ variable "security_groups" {
 }
 
 variable "instance_type" {
-  type    = string
-  default = "c5.2xlarge"
+  type        = string
+  description = "instance type to deploy"
+  default     = "c5.2xlarge"
+}
+
+variable "instance_owner" {
+  type        = list(string)
+  description = "List of AMI owners to limit search. At least 1 value must be specified. Valid values: an AWS account ID, self (the current account), or an AWS owner alias (e.g. amazon, aws-marketplace, microsoft). Default to centos public account"
+  default     = ["125523088429"]
+}
+variable "instance_filter" {
+  type = list(object({
+    name   = string
+    values = list(string)
+  }))
+  description = "provide a map of filter to search Instance ID (see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami)"
+  default = [{
+    name   = "name"
+    values = ["CentOS 7.9.2009 x86_64"]
+  }]
 }
 
 variable "instance_user" {
-  type    = string
-  default = "jmeter"
+  type        = string
+  default     = "jmeter"
+  description = "service account to run jmeter"
 }
 
 variable "jmeter_version" {
-  type    = string
-  default = "5.1.1"
+  type        = string
+  default     = "5.1.1"
+  description = "jmeter version"
 }
 
 variable "authorized_keys" {
-  type = list(any)
+  type        = list(any)
+  description = "list of ssh pub key allowed to ssh"
 }
-
+variable "jmeter_scenario" {
+  type        = string
+  default     = "./jmeter.jmx"
+  description = "a path to a jmeter jmx file tu upload to the ec2 it will be uploaded to /tmp/jmeter.jmx"
+}
 variable "trusted_ip_ranges" {
   description = "List of IP ranges to whitelist for ICMP and SSH ingress."
   type        = list(string)

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.14"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Add filter as variable (and change default value to point to public centos to get rid of marketplace authorisation
Add variable to pass a path to a jmeter.jmx file to upload to the EC2
Improve doc